### PR TITLE
Use `setup.py install` instead of `pip install --process-dependency-links`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.*env*/
 build/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - pip install codecov
 - pip install requests
 install:
-- pip install --process-dependency-links  .
+- python ./setup.py install
 - python get-iaca.py --i-accept-the-What-If-Pre-Release-License-Agreement-and-please-take-my-soul
   lin64
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Installation
 ============
 
 Run:
-``pip install --process-dependency-links kerncraft``
+``python ./setup.py install``
 
 Additional requirements are:
  * Intel IACA tool, with (working) ``iaca.sh`` in PATH environment variable (used by ECM, ECMCPU and Roofline models)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
@@ -65,7 +67,7 @@ setup(
 
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
-    
+
     # what is not found or up-to-date on pypi we get from github:
     #dependency_links = ['https://github.com/sympy/sympy/tarball/master#egg=sympy-0.7.7.dev0'],
 


### PR DESCRIPTION
Fixes deprecation warning of pip:

> DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release.