### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
 
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ruamel.yaml>=0.13.4',
+        'ruamel.yaml>=0.13.4,<0.15',
         'six',
         'sympy>=0.7.7',
         'pycachesim>=0.1.4',


### PR DESCRIPTION
There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.