### PR TITLE
Remove DeprecationWarning: use collections.abc.Sequence instead of collections.Sequence

### DIFF
--- a/kerncraft/kernel.py
+++ b/kerncraft/kernel.py
@@ -524,7 +524,7 @@ class Kernel(object):
         if isinstance(iteration, range):
             iteration = numpy.arange(iteration.start, iteration.stop, iteration.step, dtype='O')
         else:
-            if not isinstance(iteration, collections.Sequence):
+            if not isinstance(iteration, collections.abc.Sequence):
                 iteration = [iteration]
             iteration = numpy.array(iteration, dtype='O')
 


### PR DESCRIPTION

Warning was:
```
/opt/conda/envs/pystencils_dev/lib/python3.7/site-packages/kerncraft/kernel.py:488:
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop
working
```