### PR TITLE
Bugfix: step width in iteration_length

### DIFF
--- a/kerncraft/kernel.py
+++ b/kerncraft/kernel.py
@@ -37,6 +37,7 @@ from . import kerncraft
 from . import incore_model
 from .pycparser_utils import clean_code, replace_id
 
+from kerncraft.symbolic.utils import int_ceil
 
 class LessParanthesizingCGenerator(CGenerator):
     def get_BinaryOp_precedence(self, n):
@@ -420,7 +421,7 @@ class Kernel(object):
 
         for var_name, start, end, incr in loops:
             # This unspools the iterations:
-            length = end-start
+            length = int_ceil((end-start), incr)
             total_length = total_length*length
         return self.subs_consts(total_length)
 

--- a/kerncraft/kernel.py
+++ b/kerncraft/kernel.py
@@ -515,7 +515,7 @@ class Kernel(object):
             loop_var = symbol_pos_int(var_name)
 
             # This unspools the iterations:
-            length = end-start  # FIXME is incr handled correct here?
+            length = int_ceil((end-start), incr)
             counter = start+(((global_iterator*last_incr) // total_length)*incr) % length
             total_length = total_length*length
             last_incr = incr
@@ -543,7 +543,7 @@ class Kernel(object):
         total_length = sympy.Integer(1)
         for var_name, start, end, incr in reversed(self._loop_stack):
             loop_var = symbol_pos_int(var_name)
-            length = end - start  # FIXME is incr handled correct here?
+            length = int_ceil((end-start), incr)
             global_iterator += (loop_var - start) * total_length
             total_length *= length
         return global_iterator

--- a/kerncraft/symbolic/__init__.py
+++ b/kerncraft/symbolic/__init__.py
@@ -1,0 +1,1 @@
+from kerncraft.symbolic.utils import int_ceil, int_floor

--- a/kerncraft/symbolic/utils.py
+++ b/kerncraft/symbolic/utils.py
@@ -1,0 +1,19 @@
+import sympy
+
+class int_floor(sympy.Function):
+    @classmethod
+    def eval(cls, x, y):
+        if x.is_Number and y.is_Number:
+            return x // y
+
+    def _eval_is_integer(self):
+        return True
+
+class int_ceil(sympy.Function):
+    @classmethod
+    def eval(cls, x, y):
+        if x.is_Number and y.is_Number:
+            return sympy.ceiling(x / y)
+
+    def _eval_is_integer(self):
+        return True


### PR DESCRIPTION
Hello,

I am working on some synthetic stencils with your nice tool, but I have some problems getting them analyzed. I am basically parsing the stencils from python into the YAML format and then constructing the KernelDescription object manually. I've attached an example as a .zip file.

This first problem was that in the "SIM" mode of cache prediction, the max_iterations are heavily over-estimated because the iteration_length function in kernel.py ignores the step width of the loop. This is not too dramatic for shallow loop nests but grows exponentially for deeper loop nests (see *kernel_tiled.yaml*). I discovered it on the tiling example, where the max iterations are estimated > 10e9 (N = 256) which easily causes overflows. I've provided a fix avoiding sympy's strange integer division. I hope this does not break anything downwards, but according to your paper constant step sizes and it's not the LC mode anyway, right?

However, I am still worried about the boundary conditions. kerncraft does not support using loop variables in the definition of lower-level loops, so I can't express the boundary condition that i_0 and i_1 shall stop at the array boundaries rather than doing the full tile. For the max_iterations, I think it's fine to approximate this roughly, but what happens in the actual simulation? It would be nice if my *kernel_with_boundary_conditions.yaml* was supported.

In general, I am curious about using the LC mode for my problems, cause speed of analysis is a factor as well. However, in order to use LC, I would need to "further normalize" the loops (step width = 1) and move the step widths as multiplications into the data accesses (A[i_0 + **128** * tile_size_i_0]). I actually tried that and ran into the exception that the multiplication order in the access does not correspond to the loop order. I didn't understand this from the pure code but also didn't continue on this path as there is no way to not violate the boundary conditions then. Is this correct or is there an option to make the tiling example work with the LC? If not, is it theoretically or sympy-related?

I guess, constructing the KernelDescription manually from a dict is not the standard use case, but it would be nice if you could add more support for this (also some more documentation and examples).

[kernel.zip](https://github.com/RRZE-HPC/kerncraft/files/8087608/kernel.zip)